### PR TITLE
Autoriser le débogage réseau local sur iOS

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,9 +41,15 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>CADisableMinimumFrameDurationOnPhone</key>
+        <true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>NSLocalNetworkUsageDescription</key>
+        <string>Permettre le débogage via le réseau local</string>
+        <key>NSBonjourServices</key>
+        <array>
+                <string>_dartobservatory._tcp</string>
+        </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Résumé
- Déclaration de l’usage du réseau local pour le débogage.
- Publication du service Bonjour `_dartobservatory._tcp`.

## Tests
- `flutter analyze` *(échoué : commande introuvable)*
- `flutter test` *(échoué : commande introuvable)*
- `apt-get update` *(échoué : repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892095f27d8832d83ca4147fa8c09f0