### PR TITLE
feat: ajouter page de menu

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'pages/menu_page.dart';
 import 'pages/search_page.dart';
 import 'pages/quiz_page.dart';
 
@@ -17,35 +18,11 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
         useMaterial3: true,
       ),
-      home: const HomePage(),
-    );
-  }
-}
-
-class HomePage extends StatelessWidget {
-  const HomePage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return DefaultTabController(
-      length: 2,
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Code Civil'),
-          bottom: const TabBar(
-            tabs: [
-              Tab(text: 'Recherche'),
-              Tab(text: 'Quiz'),
-            ],
-          ),
-        ),
-        body: const TabBarView(
-          children: [
-            SearchPage(),
-            QuizPage(),
-          ],
-        ),
-      ),
+      routes: {
+        '/search': (_) => const SearchPage(),
+        '/quiz': (_) => const QuizPage(),
+      },
+      home: const MenuPage(),
     );
   }
 }

--- a/lib/pages/menu_page.dart
+++ b/lib/pages/menu_page.dart
@@ -1,0 +1,149 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+import 'search_page.dart';
+import 'quiz_page.dart';
+
+class MenuPage extends StatefulWidget {
+  const MenuPage({super.key});
+
+  @override
+  State<MenuPage> createState() => _MenuPageState();
+}
+
+class _MenuPageState extends State<MenuPage> {
+  List<dynamic> _articles = [];
+  Map<String, dynamic>? _current;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadArticles();
+  }
+
+  Future<void> _loadArticles() async {
+    final data = await rootBundle.loadString('assets/code_civil.json');
+    final List<dynamic> list = json.decode(data) as List<dynamic>;
+    setState(() {
+      _articles = list;
+      _current = _pickRandom();
+    });
+  }
+
+  Map<String, dynamic>? _pickRandom() {
+    if (_articles.isEmpty) return null;
+    final index = Random().nextInt(_articles.length);
+    return _articles[index] as Map<String, dynamic>;
+  }
+
+  void _refresh() {
+    setState(() {
+      _current = _pickRandom();
+    });
+  }
+
+  void _goToSearch() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const SearchPage()),
+    );
+  }
+
+  void _goToQuiz() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => const QuizPage()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final article = _current;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Menu'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _refresh,
+            tooltip: 'Nouvel article',
+          ),
+        ],
+      ),
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF0f2027), Color(0xFF203a43), Color(0xFF2c5364)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (article != null)
+                Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        article['numero'] as String? ?? '',
+                        style: Theme.of(context)
+                            .textTheme
+                            .titleLarge
+                            ?.copyWith(color: Colors.white),
+                      ),
+                      const SizedBox(height: 8),
+                      if ((article['titre'] as String?)?.isNotEmpty ?? false)
+                        Text(
+                          article['titre'] as String,
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleMedium
+                              ?.copyWith(color: Colors.white70),
+                        ),
+                      const SizedBox(height: 8),
+                      Text(
+                        article['texte'] as String? ?? '',
+                        style: Theme.of(context)
+                            .textTheme
+                            .bodyLarge
+                            ?.copyWith(color: Colors.white),
+                      ),
+                    ],
+                  ),
+                )
+              else
+                const Expanded(
+                  child: Center(child: CircularProgressIndicator()),
+                ),
+              const Spacer(),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: ElevatedButton.icon(
+                  onPressed: _goToSearch,
+                  icon: const Icon(Icons.search),
+                  label: const Text('Recherche'),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: ElevatedButton.icon(
+                  onPressed: _goToQuiz,
+                  icon: const Icon(Icons.quiz),
+                  label: const Text('Quiz'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -64,6 +64,7 @@ flutter:
     - assets/pic.png
     - assets/articles.json # Texte consolidé 2025
     - assets/quiz_questions.json
+    - assets/code_civil.json
     # - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,11 +5,11 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:codeciv/main.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('affiche les onglets Recherche et Quiz', (tester) async {
+  testWidgets('affiche les boutons Recherche et Quiz', (tester) async {
     await tester.pumpWidget(const MyApp());
 
     expect(find.text('Recherche'), findsOneWidget);


### PR DESCRIPTION
## Résumé
- ajouter une page de menu proposant un article aléatoire
- naviguer vers la recherche et le quiz depuis le menu
- déclarer la nouvelle ressource JSON et adapter le test widget

## Tests
- `flutter test` *(échoué: commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68920b80862c832d8c20b3b160314adc